### PR TITLE
`get_time_entries()`: Add support for multiple tags

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# togglr 0.1.34.9000
+
+* `get_time_entries()` can now handle multiple tags, stored in a list column (#21, @pat-s)
+
+
 # togglr 0.1.34
 
 * Added pkgdown documentation

--- a/R/Get_time_entries.R
+++ b/R/Get_time_entries.R
@@ -1,8 +1,3 @@
-paste2 <- function(x,...){
-  if (!is.list(x)){return(x)}
-  paste(x,...)
-}
-
 #' Get all time entries between 2 dates
 #'
 #' @param since begin date (One week ago by default)
@@ -24,43 +19,59 @@ paste2 <- function(x,...){
 #' }
 get_time_entries <- function(api_token = get_toggl_api_token(),
                              since = Sys.time() - lubridate::weeks(1),
-                             until = Sys.time()){
+                             until = Sys.time()) {
   url <- glue::glue("https://www.toggl.com/api/v8/time_entries?start_date={format_iso_8601(since)}&end_date={format_iso_8601(until)}")
   res <- content(GET(url,
-              # verbose(),
-              authenticate(api_token, "api_token"),
-              encode = "json"))
-  
-  if (length(res)==0) {return(data.frame())}
-  
+    # verbose(),
+    authenticate(api_token, "api_token"),
+    encode = "json"
+  ))
+
+  if (length(res) == 0) {
+    return(data.frame())
+  }
+
+  # extract list of tags
+  tags <- map(res, ~ .x$tags)
+
   res %>%
-    # map_df(invisible) %>%
-    
-    map(~map(.x,paste2,collapse=";")) %>%
-    bind_rows() %>% 
+    # remove tags column, otherwise bind_rows() adds additional rows if
+    # length(tags) > 1
+    map(~ {
+      .x$tags <- NULL
+      return(.x)
+    }) %>%
+    bind_rows() %>%
+    # add list column
+    mutate(tags = tags) %>% 
     mutate(
-      start = parse_iso_8601(start)  ,
-      duration = case_when(duration < 0 ~ as.integer(difftime(
-        Sys.time(), start, units = "sec"
-      )),
-      TRUE ~ duration)
-      ,
-      pretty_duration = prettyunits::pretty_sec(duration)
-      ,
-      stop = case_when(is.na(stop) ~ "0",
-                       TRUE ~ stop),
+      start = parse_iso_8601(start),
+      duration = case_when(
+        duration < 0 ~ as.integer(difftime(
+          Sys.time(), start,
+          units = "sec"
+        )),
+        TRUE ~ duration
+      ),
+      pretty_duration = prettyunits::pretty_sec(duration),
+      stop = case_when(
+        is.na(stop) ~ "0",
+        TRUE ~ stop
+      ),
       stop = parse_iso_8601(stop)
-    ) %>% 
-    left_join(get_project_id_and_name(),by= c("pid"="id"))%>%
-    select(start,
-           stop,
-           pretty_duration,
-           duration,
-           project_name,
-           description,
-           pid,
-           wid,
-           everything()) %>%
-    slice(nrow(.):1) 
-  
+    ) %>%
+    left_join(get_project_id_and_name(), by = c("pid" = "id")) %>%
+    select(
+      start,
+      stop,
+      pretty_duration,
+      duration,
+      project_name,
+      description,
+      pid,
+      wid,
+      everything()
+    ) %>%
+    slice(nrow(.):1)
+
 }


### PR DESCRIPTION
fixes #21 

Tags are returned in a list column.
Also, `paste2()` was replaced by a `map()` call removing the list column before binding the rows together (which I think was the purpose if the function before).

You might want to double-check this.