### PR TITLE
Fix for when the user does not have any projects. 

### DIFF
--- a/R/get_project.R
+++ b/R/get_project.R
@@ -22,7 +22,8 @@ get_project_id <- function(project_name = get_context_project(),
     stop("you have to set your api token using set_toggl_api_token('XXXXXXXX')")
     
   }
-  content(GET(
+  
+  project_tbl <- content(GET(
     paste0(
       "https://www.toggl.com/api/v8/workspaces/",
       workspace_id,
@@ -31,8 +32,14 @@ get_project_id <- function(project_name = get_context_project(),
     # verbose(),
     authenticate(api_token, "api_token"),
     encode = "json"
-  )) %>% bind_rows() %>%
-    filter(name == project_name) %>% .$id -> id
+  )) %>% bind_rows()
+  
+  if (ncol(project_tbl) == 0) {
+    id <- NULL
+  } else {
+    project_tbl %>%
+      filter(name == project_name) %>% .$id -> id
+  }
   
   if (length(id) == 0) {
     warning(paste("the project ", project_name, " doesn't exist "))


### PR DESCRIPTION
The error occurs within filter; the GET request returns a data frame with 0 columns.

``` r
togglr::toggl_start()
#> Error: Problem with `filter()` input `..1`.
#> x object 'name' not found
#> i Input `..1` is `name == project_name`.
```

<sup>Created on 2020-07-16 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
  
This fix checks if there are are any columns after `bind_rows()` and sets to id to `NULL` if there are no columns.