### PR TITLE
Update Toggle API URLs (fix #29)

### DIFF
--- a/R/Get_time_entries.R
+++ b/R/Get_time_entries.R
@@ -20,7 +20,7 @@
 get_time_entries <- function(api_token = get_toggl_api_token(),
                              since = Sys.time() - lubridate::weeks(1),
                              until = Sys.time()) {
-  url <- glue::glue("https://www.toggl.com/api/v8/time_entries?start_date={format_iso_8601(since)}&end_date={format_iso_8601(until)}")
+  url <- glue::glue("https://api.track.toggl.com/api/v8/time_entries?start_date={format_iso_8601(since)}&end_date={format_iso_8601(until)}")
   res <- content(GET(url,
     # verbose(),
     authenticate(api_token, "api_token"),

--- a/R/client.R
+++ b/R/client.R
@@ -20,9 +20,9 @@ create_client <- function(name = "wihtout client",
                           workspace_id = get_workspace_id(api_token)
                           ){
 
-# POST https://www.toggl.com/api/v8/clients
+# POST https://api.track.toggl.com/api/v8/clients
 message(glue("we create the client : {name}"))
-POST("https://www.toggl.com/api/v8/clients",
+POST("https://api.track.toggl.com/api/v8/clients",
      verbose(),
      authenticate(api_token,"api_token"),
      encode="json",
@@ -49,7 +49,7 @@ POST("https://www.toggl.com/api/v8/clients",
 #' }
 #' @export
 get_all_client_info <- function(api_token=get_toggl_api_token()){
-  GET("https://www.toggl.com/api/v8/clients",authenticate(api_token,"api_token")) %>% content() %>% bind_rows()
+  GET("https://api.track.toggl.com/api/v8/clients",authenticate(api_token,"api_token")) %>% content() %>% bind_rows()
 }
 
 
@@ -99,7 +99,7 @@ client_id_to_name <- function(id, api_token = get_toggl_api_token()) {
 #'
 get_client_project <- function(id,api_token=get_toggl_api_token()){
   
-  GET(glue("https://www.toggl.com/api/v8/clients/{id}/projects"),authenticate(api_token,"api_token")) %>% content() %>% bind_rows()
+  GET(glue("https://api.track.toggl.com/api/v8/clients/{id}/projects"),authenticate(api_token,"api_token")) %>% content() %>% bind_rows()
   
 
 }

--- a/R/get.R
+++ b/R/get.R
@@ -25,7 +25,7 @@ get_current <- function(api_token=get_toggl_api_token()){
     stop("you have to set your api token using set_toggl_api_token('XXXXXXXX')")
     
   }
-  content(GET("https://www.toggl.com/api/v8/time_entries/current",
+  content(GET("https://api.track.toggl.com/api/v8/time_entries/current",
               # verbose(),
               authenticate(api_token,"api_token"),
               encode="json"))$data

--- a/R/get_dashboard.R
+++ b/R/get_dashboard.R
@@ -18,7 +18,7 @@ get_dashboard <- function(api_token = get_toggl_api_token(),
                           until = Sys.Date()) {
   url <-
     sprintf(
-      "https://toggl.com/reports/api/v2/summary?workspace_id=%s&since=%s&until=%s&user_agent=api_test",
+      "https://api.toggl.com/reports/api/v2/summary?workspace_id=%s&since=%s&until=%s&user_agent=api_test",
       workspace_id,
       format(since, "%Y-%m-%d"),
       format(until, "%Y-%m-%d")

--- a/R/get_detailled_report.R
+++ b/R/get_detailled_report.R
@@ -32,7 +32,7 @@ get_detailled_report_paged <- function(api_token = get_toggl_api_token(),
  
   
   
-  url <- glue("https://toggl.com/reports/api/v2/details?workspace_id={workspace_id}&since={since}&until={until}&user_agent={user_agent}&grouping=users&page={page}",
+  url <- glue("https://api.toggl.com/reports/api/v2/details?workspace_id={workspace_id}&since={since}&until={until}&user_agent={user_agent}&grouping=users&page={page}",
                     since=format(since, "%Y-%m-%dT00:00:00"),
                     until=format(until, "%Y-%m-%dT00:00:00")
   )

--- a/R/get_project.R
+++ b/R/get_project.R
@@ -25,7 +25,7 @@ get_project_id <- function(project_name = get_context_project(),
   
   project_tbl <- content(GET(
     paste0(
-      "https://www.toggl.com/api/v8/workspaces/",
+      "https://api.track.toggl.com/api/v8/workspaces/",
       workspace_id,
       "/projects"
     ),
@@ -84,7 +84,7 @@ get_project_id_and_name <- function(
   }
   content(GET(
     paste0(
-      "https://www.toggl.com/api/v8/workspaces/",
+      "https://api.track.toggl.com/api/v8/workspaces/",
       workspace_id,
       "/projects"
     ),

--- a/R/get_summary_report.R
+++ b/R/get_summary_report.R
@@ -26,7 +26,7 @@ get_summary_report <- function(api_token = get_toggl_api_token(),
                               ) {
   
   
-  url <- glue::glue("https://toggl.com/reports/api/v2/summary?workspace_id={workspace_id}&since={since}&until={until}&user_agent={user_agent}&grouping=users",
+  url <- glue::glue("https://api.toggl.com/reports/api/v2/summary?workspace_id={workspace_id}&since={since}&until={until}&user_agent={user_agent}&grouping=users",
                     since=format(since, "%Y-%m-%d"),
                     until=format(until, "%Y-%m-%d")
                     

--- a/R/get_weekly_report.R
+++ b/R/get_weekly_report.R
@@ -21,7 +21,7 @@ get_weekly_report <- function(api_token = get_toggl_api_token(),
                           user_agent="togglr") {
   
   
-  url <- glue::glue("https://toggl.com/reports/api/v2/weekly?workspace_id={workspace_id}&since={since}&until={until}&user_agent={user_agent}",
+  url <- glue::glue("https://api.toggl.com/reports/api/v2/weekly?workspace_id={workspace_id}&since={since}&until={until}&user_agent={user_agent}",
                     
                     since=format(since, "%Y-%m-%d"),
                     until=format(until, "%Y-%m-%d")

--- a/R/get_workspace.R
+++ b/R/get_workspace.R
@@ -11,7 +11,7 @@ get_workspace_id <- function(
     stop("you have to set your api token using set_toggl_api_token('XXXXXXXX')")
 
   }
-  content(GET("https://www.toggl.com/api/v8/workspaces",
+  content(GET("https://api.track.toggl.com/api/v8/workspaces",
               # verbose(),
               authenticate(api_token,"api_token"),
               encode="json")) %>%

--- a/R/get_workspace_users.R
+++ b/R/get_workspace_users.R
@@ -8,7 +8,7 @@
 get_workspace_users <- function(api_token = get_toggl_api_token(),
                                 workspace_id = get_workspace_id(api_token)){
   
-  url <- glue::glue("https://www.toggl.com/api/v8/workspaces/{workspace_id}/users")
+  url <- glue::glue("https://api.track.toggl.com/api/v8/workspaces/{workspace_id}/users")
   
   wp <- content(GET(url,
                     # verbose(),

--- a/R/open_toggl.R
+++ b/R/open_toggl.R
@@ -4,8 +4,8 @@
 #' @importFrom utils browseURL
 #'
 open_toggl_website_profile <- function(){
-  message("opening https://toggl.com/app/profile")
-  browseURL("https://toggl.com/app/profile")
+  message("opening https://track.toggl.com/profile")
+  browseURL("https://track.toggl.com/profile")
   
 }
 
@@ -15,7 +15,7 @@ open_toggl_website_profile <- function(){
 #' @importFrom utils browseURL
 #'
 open_toggl_website_app <- function(){
-  message("opening https://toggl.com/app")
-  browseURL("https://toggl.com/app")
+  message("opening https://track.toggl.com/timer")
+  browseURL("https://track.toggl.com/timer")
   
 }

--- a/R/put.R
+++ b/R/put.R
@@ -38,7 +38,7 @@ toggl_start <- function(description = get_context(),
   
   
   POST(
-    "https://www.toggl.com/api/v8/time_entries/start",
+    "https://api.track.toggl.com/api/v8/time_entries/start",
     # verbose(),
     authenticate(api_token, "api_token"),
     encode = "json",
@@ -106,7 +106,7 @@ toggl_stop <- function(current=get_current(),
     stop("i can't find any task to stop...")
     
   }
-  PUT(paste0("https://www.toggl.com/api/v8/time_entries/",current$id,"/stop"),
+  PUT(paste0("https://api.track.toggl.com/api/v8/time_entries/",current$id,"/stop"),
 
        # verbose(),
        authenticate(api_token,"api_token"),
@@ -186,7 +186,7 @@ toggl_create <- function(
   }
 
 
-  POST("https://www.toggl.com/api/v8/time_entries",
+  POST("https://api.track.toggl.com/api/v8/time_entries",
        verbose(),
        authenticate(api_token,"api_token"),
        encode="json",

--- a/R/put_project.R
+++ b/R/put_project.R
@@ -41,7 +41,7 @@ toggl_create_project <- function(
     
     
     
-  POST("https://www.toggl.com/api/v8/projects",
+  POST("https://api.track.toggl.com/api/v8/projects",
        verbose(),
        authenticate(api_token,"api_token"),
        encode="json",

--- a/R/put_update_time_entries.R
+++ b/R/put_update_time_entries.R
@@ -63,7 +63,7 @@ toggl_update_entries <- function(
 
   POST(
     paste0(
-      "https://www.toggl.com/api/v8/time_entries/",
+      "https://api.track.toggl.com/api/v8/time_entries/",
       # Separate multiple ids with commas
       paste(time_entry_ids, collapse = ",")
     ),

--- a/README.Rmd
+++ b/README.Rmd
@@ -46,7 +46,7 @@ devtools::install_github("ThinkR-open/togglr")
 
 ## Set toggl Api token
 
-Go on toogl.com website : `https://toggl.com/app/profile` 
+Go on toogl.com website : `https://track.toggl.com/profile`
 
 ```{r}
 togglr::open_toggl_website_profile()

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ devtools::install_github("ThinkR-open/togglr")
 
 ## Set toggl Api token
 
-Go on toogl.com website : `https://toggl.com/app/profile`
+Go on toogl.com website : `https://track.toggl.com/profile`
 
 ``` r
 togglr::open_toggl_website_profile()


### PR DESCRIPTION
This PR updates all URLs in the package to the new Toggl Track URLs. The old API will be removed in the coming days, as  mentioned by @gilberthdez in #29.