### PR TITLE
ci: bump deprecated GitHub Actions versions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,15 +41,15 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         id: install-r
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Install pak and query dependencies
         run: |
@@ -58,7 +58,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache R packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ matrix.config.os }}-${{ steps.install-r.outputs.installed-r-version }}-1-${{ hashFiles('.github/r-depends.rds') }}


### PR DESCRIPTION
## Summary
Bump deprecated GitHub Actions to currently-supported majors. No behavioural change intended.

## Bumps applied (where present)
- `actions/checkout` v1/v2/v3 → v4
- `actions/cache` v1/v2/v3 → v4
- `actions/upload-artifact` v1/v2/v3 → v4
- `actions/download-artifact` v1.x/v2/v3 → v4
- `r-lib/actions/*` @v1 → @v2
- `r-lib/actions/setup-tinytex` @master → @v2

## Test plan
- [ ] CI runs green on this PR